### PR TITLE
Prevent index out of range error

### DIFF
--- a/gtt/util.go
+++ b/gtt/util.go
@@ -100,6 +100,9 @@ func match(result interface{}, expect interface{}) ([]string, interface{}, inter
 		}
 	case []interface{}:
 		if ra, ok := result.([]interface{}); ok {
+			if len(ra) != len(x) {
+				return []string{}, nil, expect
+			}
 			for i, v := range x {
 				if loc, av, xv := match(ra[i], v); loc != nil {
 					return append([]string{strconv.Itoa(i)}, loc...), av, xv

--- a/gtt/util.go
+++ b/gtt/util.go
@@ -100,13 +100,16 @@ func match(result interface{}, expect interface{}) ([]string, interface{}, inter
 		}
 	case []interface{}:
 		if ra, ok := result.([]interface{}); ok {
-			if len(ra) != len(x) {
-				return []string{}, nil, expect
-			}
 			for i, v := range x {
+				if len(ra) <= i {
+					return []string{}, nil, v
+				}
 				if loc, av, xv := match(ra[i], v); loc != nil {
 					return append([]string{strconv.Itoa(i)}, loc...), av, xv
 				}
+			}
+			if len(ra) > len(x) {
+				return []string{}, ra, x
 			}
 		} else {
 			return []string{}, result, expect


### PR DESCRIPTION
If `ra` has fewer elements than `x`, an out of range error will occur. I'm not certain if my return value is correct, it may need to be tweaked.