### PR TITLE
Allow regex to be used when expecting strings from html response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All changes to the GraphQL Test Tool (gtt) are documented here. Releases follow 
 
 ## [Unreleased]
 
+## [1.0.10] - [2020-01-02]
+
+Enable linewise regex match when expecting strings
+
 ## [1.0.9] - [2019-12-31]
 
 Sort nested arrays

--- a/gtt/step.go
+++ b/gtt/step.go
@@ -275,11 +275,6 @@ func (s *Step) expectJSON(status int, actual []byte, uc *UseCase) (err error) {
 }
 
 func (s *Step) expectString(expect, actual string, r *Runner) (err error) {
-	if expect == actual {
-		r.Log(aResponse, "%s", actual)
-		return nil
-	}
-	// Find were the mismatch is.
 	var buf strings.Builder
 
 	lines := strings.Split(actual, "\n")
@@ -294,7 +289,7 @@ func (s *Step) expectString(expect, actual string, r *Runner) (err error) {
 			break
 		}
 		aline := lines[i]
-		if xline == aline {
+		if path, _, _ := match(aline, xline); path == nil {
 			buf.WriteString(aline)
 			buf.WriteByte('\n')
 			continue

--- a/gtt/util.go
+++ b/gtt/util.go
@@ -86,6 +86,7 @@ func addAny(m map[string]interface{}, key string, value interface{}) {
 
 // compare results
 
+// Returns path, result, expected
 func match(result interface{}, expect interface{}) ([]string, interface{}, interface{}) {
 	switch x := expect.(type) {
 	case map[string]interface{}:


### PR DESCRIPTION
When `expectString` is called it was not checking if the line was a regex.
This prevents use-cases that expect an array of strings, where a regex for a particular line can be specified. This behavior is useful when evaluating the HTML response from a server that has dynamic content

Example:
```
...
"expect": [
  "Line 1 - regular matching",
  "/ Line \\d - regex match /",
  "Line 3 - regular matching"
]